### PR TITLE
Handle case where port is already in use

### DIFF
--- a/django_debugger/management/commands/runserver.py
+++ b/django_debugger/management/commands/runserver.py
@@ -23,8 +23,13 @@ class Command(runserver.Command):
 
                 address = getattr(settings, "DEBUGGER_ADDRESS", "0.0.0.0")
                 port = getattr(settings, "DEBUGGER_PORT", 5678)
-                debugpy.listen(address=(address, port))
-                print("Debugger: Listening at {}:{}".format(address, port))
+
+                try:
+                    debugpy.listen(address=(address, port))
+                    print("Debugger: Listening at {}:{}".format(address, port))
+                except (OSError, RuntimeError):
+                    print("Debugger: Port {} already in use").format(port)
+
                 if getattr(settings, "DEBUGGER_WAIT_FOR_ATTACH", False):
                     print("Debugger: Waiting for remote debugger to attach")
                     debugpy.wait_for_client()


### PR DESCRIPTION
This is a small change to handle exceptions that in my hands happen pretty often due to container/server restarts.