### PR TITLE
Relax debugpy version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url="https://github.com/sajalshres/django-debugger",
     keywords=["DJANGO", "DEBUGGER", "DEBUGPY", "PYTHON"],
     install_requires=[
-        "debugpy==1.3.0",
+        "debugpy>=1.3.0",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     url="https://github.com/sajalshres/django-debugger",
     keywords=["DJANGO", "DEBUGGER", "DEBUGPY", "PYTHON"],
     install_requires=[
-        "debugpy>=1.3.0",
+        "debugpy>=1.3.0,<2.0",
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This allows newer versions of `debugpy` to be installed